### PR TITLE
fix: simplify useEffect reference

### DIFF
--- a/src/components/DropdownButton.tsx
+++ b/src/components/DropdownButton.tsx
@@ -49,7 +49,7 @@ export default function DropdownButton({
     const buttonRef = React.useRef<HTMLButtonElement>(null);
     const listRef = React.useRef<Array<HTMLElement | null>>([]);
 
-    React.React.useEffect(() => {
+    React.useEffect(() => {
         setIsMounted(true);
     }, []);
 


### PR DESCRIPTION
## Summary
- remove unnecessary React namespace when using useEffect

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react', and other errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b632d1f0832fb5440e4d39694c51